### PR TITLE
feat(auth): implement email verification flow with Prisma migration and login block for unverified users

### DIFF
--- a/apps/auth-service/prisma/migrations/20250501032505_add_email_verification/migration.sql
+++ b/apps/auth-service/prisma/migrations/20250501032505_add_email_verification/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "isVerified" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "verificationToken" TEXT;

--- a/apps/auth-service/prisma/schema.prisma
+++ b/apps/auth-service/prisma/schema.prisma
@@ -14,9 +14,11 @@ datasource db {
 }
 
 model User {
-  id        String   @id @default(uuid())
-  email     String   @unique
-  password  String
-  createdAt DateTime @default(now())
-  refreshToken String?
+  id                String   @id @default(uuid())
+  email             String   @unique
+  password          String
+  createdAt         DateTime @default(now())
+  refreshToken      String?
+  isVerified        Boolean  @default(false)
+  verificationToken String?
 }

--- a/apps/auth-service/src/auth/auth.service.ts
+++ b/apps/auth-service/src/auth/auth.service.ts
@@ -2,12 +2,14 @@ import {
   Injectable,
   ConflictException,
   ForbiddenException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { SignupDto } from './dto/signup.dto';
 import { LoginDto } from './dto/login.dto';
 import * as bcrypt from 'bcrypt';
 import { PrismaService } from '../prisma/prisma.service';
 import { JwtService } from '@nestjs/jwt';
+import { randomUUID } from 'crypto';
 
 @Injectable()
 export class AuthService {
@@ -23,22 +25,26 @@ export class AuthService {
     if (existingUser) throw new ConflictException('Email already in use');
 
     const hash = await bcrypt.hash(dto.password, 10);
+    const verificationToken = randomUUID();
     const user = await this.prisma.user.create({
       data: {
         email: dto.email,
         password: hash,
+        isVerified: false,
+        verificationToken,
       },
     });
-
-    return { userId: user.id };
+    // Simulate sending email by logging the verification URL
+    console.log(`Verify your account: http://localhost:3000/auth/verify?token=${verificationToken}`);
+    return { userId: user.id, message: 'Signup successful. Please verify your email.' };
   }
 
   async login(dto: LoginDto) {
-    const user = await this.prisma.user.findUnique({
-      where: { email: dto.email },
-    });
+    const user = await this.prisma.user.findUnique({ where: { email: dto.email } });
     if (!user) throw new ForbiddenException('Invalid credentials');
-
+    if (!user.isVerified) {
+      throw new UnauthorizedException('Email not verified');
+    }
     const pwMatch = await bcrypt.compare(dto.password, user.password);
     if (!pwMatch) throw new ForbiddenException('Invalid credentials');
 


### PR DESCRIPTION
- Adds isVerified and verificationToken fields to User model via Prisma migration
- Signup generates a verification token and logs a verification link
- Adds /auth/verify endpoint to handle email verification
- Blocks login for unverified users
- All steps tested and working