### PR TITLE
feat(post-service): UserRestService for user profile/following via REST, refactor PostsService, env-based user service URL (Day 35)

### DIFF
--- a/apps/post-service/package-lock.json
+++ b/apps/post-service/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
         "@prisma/client": "^6.7.0",
+        "axios": "^1.9.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "passport": "^0.7.0",
@@ -4973,7 +4974,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
       "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -6907,7 +6907,6 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -9636,8 +9635,7 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "peer": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/apps/post-service/package.json
+++ b/apps/post-service/package.json
@@ -27,6 +27,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@prisma/client": "^6.7.0",
+    "axios": "^1.9.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "passport": "^0.7.0",

--- a/apps/post-service/src/app.module.ts
+++ b/apps/post-service/src/app.module.ts
@@ -4,10 +4,12 @@ import { AppService } from './app.service';
 import { PostsModule } from './posts/posts.module';
 import { CommentsModule } from './comments/comments.module';
 import { LikesModule } from './likes/likes.module';
+import { UserRestService } from './external/user/user.rest.service';
+import { HttpModule } from '@nestjs/axios';
 
 @Module({
-  imports: [PostsModule, CommentsModule, LikesModule],
+  imports: [PostsModule, CommentsModule, LikesModule, HttpModule],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, UserRestService],
 })
 export class AppModule {}

--- a/apps/post-service/src/external/user/user.rest.service.ts
+++ b/apps/post-service/src/external/user/user.rest.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { firstValueFrom } from 'rxjs';
+import { HttpService } from '@nestjs/axios';
+
+@Injectable()
+export class UserRestService {
+  private readonly userServiceBaseUrl = process.env.USER_SERVICE_URL;
+
+  constructor(private readonly http: HttpService) {}
+
+  async getUserProfile(userId: string): Promise<any> {
+    const url = `${this.userServiceBaseUrl}/profile/${userId}`;
+    const { data } = await firstValueFrom(this.http.get(url));
+    return data;
+  }
+
+  async getFollowing(userId: string): Promise<any[]> {
+    const url = `${this.userServiceBaseUrl}/users/${userId}/following`;
+    const { data } = await firstValueFrom(this.http.get(url));
+    return data;
+  }
+}


### PR DESCRIPTION
### Day 35: Inter-service Integration

- Added `UserRestService` in `src/external/user/user.rest.service.ts` to encapsulate all REST communication with the user-service (profile and following).
- Refactored `PostsService` to use `UserRestService` for fetching profile and following info, removing direct REST calls from business logic.
- User service base URL is now configurable via `USER_SERVICE_URL` env variable.
- Updated module wiring and folder structure for clean, scalable inter-service comms.

This PR completes Day 35 objectives for secure, maintainable, and testable cross-service integration.