### PR TITLE
feat(media-service): persist media metadata to PostgreSQL with Prisma after upload (Day 37)

### DIFF
--- a/apps/media-service/prisma/schema.prisma
+++ b/apps/media-service/prisma/schema.prisma
@@ -1,0 +1,17 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Media {
+  id        String   @id @default(uuid())
+  url       String
+  type      String
+  size      Int
+  postId    String?
+  createdAt DateTime @default(now())
+}

--- a/apps/media-service/src/prisma/prisma.service.ts
+++ b/apps/media-service/src/prisma/prisma.service.ts
@@ -1,0 +1,15 @@
+import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
+  async onModuleInit() {
+    await this.$connect();
+  }
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
+}

--- a/apps/media-service/src/upload/upload.controller.ts
+++ b/apps/media-service/src/upload/upload.controller.ts
@@ -3,6 +3,7 @@ import {
   Post,
   UploadedFile,
   UseInterceptors,
+  Body,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { UploadService } from './upload.service';
@@ -13,8 +14,14 @@ export class UploadController {
 
   @Post()
   @UseInterceptors(FileInterceptor('file'))
-  async upload(@UploadedFile() file: Express.Multer.File) {
+  async upload(@UploadedFile() file: Express.Multer.File, @Body() body: any) {
     const fileUrl = await this.uploadService.uploadFile(file);
-    return { url: fileUrl };
+    const media = await this.uploadService.saveMetadata({
+      url: fileUrl,
+      type: file.mimetype,
+      size: file.size,
+      postId: body?.postId,
+    });
+    return { success: true, media };
   }
 }

--- a/apps/media-service/src/upload/upload.module.ts
+++ b/apps/media-service/src/upload/upload.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { UploadService } from './upload.service';
 import { UploadController } from './upload.controller';
 import { MulterModule } from '@nestjs/platform-express';
+import { PrismaModule } from '../prisma/prisma.module';
 
 @Module({
-  imports: [MulterModule.register()],
+  imports: [MulterModule.register(), PrismaModule],
   controllers: [UploadController],
   providers: [UploadService],
 })

--- a/apps/media-service/src/upload/upload.service.ts
+++ b/apps/media-service/src/upload/upload.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import * as AWS from 'aws-sdk';
+import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
 export class UploadService {
@@ -8,6 +9,8 @@ export class UploadService {
     accessKeyId: process.env.S3_ACCESS_KEY,
     secretAccessKey: process.env.S3_SECRET_KEY,
   });
+
+  constructor(private readonly prisma: PrismaService) {}
 
   async uploadFile(file: Express.Multer.File): Promise<string> {
     const uploadResult = await this.s3
@@ -20,5 +23,14 @@ export class UploadService {
       .promise();
 
     return uploadResult.Location;
+  }
+
+  async saveMetadata(data: {
+    url: string;
+    type: string;
+    size: number;
+    postId?: string;
+  }) {
+    return this.prisma.media.create({ data });
   }
 }


### PR DESCRIPTION
- Store uploaded media metadata (url, type, size, postId) in PostgreSQL using Prisma after S3 upload
- Added saveMetadata method to UploadService
- Wired up PrismaService and module
- Updated schema.prisma for Media model

Completes Day 37: Save Media Metadata