### PR TITLE
feat(media-service): implement Day 38 media-post association (post-association module, refactor, and route clarity)

### DIFF
--- a/apps/media-service/src/post-association/post-association.controller.ts
+++ b/apps/media-service/src/post-association/post-association.controller.ts
@@ -1,0 +1,15 @@
+import { Body, Controller, Patch } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Controller('media')
+export class PostAssociationController {
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Patch('associate')
+  async associatePostToMedia(@Body() dto: { mediaId: string; postId: string }) {
+    return this.prisma.media.update({
+      where: { id: dto.mediaId },
+      data: { postId: dto.postId },
+    });
+  }
+}

--- a/apps/media-service/src/post-association/post-association.module.ts
+++ b/apps/media-service/src/post-association/post-association.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { PostAssociationController } from './post-association.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [PostAssociationController],
+})
+export class PostAssociationModule {}

--- a/apps/media-service/src/upload/upload.module.ts
+++ b/apps/media-service/src/upload/upload.module.ts
@@ -3,9 +3,10 @@ import { UploadService } from './upload.service';
 import { UploadController } from './upload.controller';
 import { MulterModule } from '@nestjs/platform-express';
 import { PrismaModule } from '../prisma/prisma.module';
+import { PostAssociationModule } from '../post-association/post-association.module';
 
 @Module({
-  imports: [MulterModule.register(), PrismaModule],
+  imports: [MulterModule.register(), PrismaModule, PostAssociationModule],
   controllers: [UploadController],
   providers: [UploadService],
 })

--- a/apps/post-service/src/external/media/media.rest.service.ts
+++ b/apps/post-service/src/external/media/media.rest.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+
+@Injectable()
+export class MediaRestService {
+  constructor(private readonly http: HttpService) {}
+
+  async associateMediaToPost(mediaId: string, postId: string): Promise<any> {
+    const res = await this.http.axiosRef.patch(
+      `${process.env.MEDIA_SERVICE_URL}/media/associate`,
+      {
+        mediaId,
+        postId,
+      },
+    );
+    return res.data;
+  }
+}

--- a/apps/post-service/src/posts/dto/create-post.dto.ts
+++ b/apps/post-service/src/posts/dto/create-post.dto.ts
@@ -12,4 +12,8 @@ export class CreatePostDto {
   @IsOptional()
   @IsString()
   mediaUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  mediaId?: string;
 }

--- a/apps/post-service/src/posts/posts.module.ts
+++ b/apps/post-service/src/posts/posts.module.ts
@@ -2,10 +2,13 @@ import { Module } from '@nestjs/common';
 import { PostsService } from './posts.service';
 import { PostsController } from './posts.controller';
 import { PrismaModule } from '../prisma/prisma.module';
+import { UserRestService } from '../external/user/user.rest.service';
+import { MediaRestService } from '../external/media/media.rest.service';
+import { HttpModule } from '@nestjs/axios';
 
 @Module({
-  imports: [PrismaModule],
-  providers: [PostsService],
+  imports: [PrismaModule, HttpModule],
+  providers: [PostsService, UserRestService, MediaRestService],
   controllers: [PostsController],
 })
 export class PostsModule {}

--- a/apps/post-service/src/posts/posts.service.ts
+++ b/apps/post-service/src/posts/posts.service.ts
@@ -1,26 +1,44 @@
-import { Injectable, ConflictException } from '@nestjs/common';
-import { HttpService } from '@nestjs/axios';
+import {
+  Injectable,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
 import { CreatePostDto } from './dto/create-post.dto';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { LikePostDto } from './dto/like-post.dto';
-import { firstValueFrom } from 'rxjs';
 import { UserRestService } from 'src/external/user/user.rest.service';
+import { MediaRestService } from 'src/external/media/media.rest.service';
 
 @Injectable()
 export class PostsService {
   constructor(
     private prisma: PrismaService,
-    private httpService: HttpService,
     private userRestService: UserRestService,
+    private mediaRestService: MediaRestService,
   ) {}
 
-  create(createPostDto: CreatePostDto) {
-    return this.prisma.post.create({
+  async create(createPostDto: CreatePostDto) {
+    const post = await this.prisma.post.create({
       data: {
-        ...createPostDto,
+        userId: createPostDto.userId,
+        content: createPostDto.content,
+        mediaUrl: undefined,
       },
     });
+
+    if (createPostDto.mediaId) {
+      const media = await this.mediaRestService.associateMediaToPost(
+        createPostDto.mediaId,
+        post.id,
+      );
+      await this.prisma.post.update({
+        where: { id: post.id },
+        data: { mediaUrl: media.url },
+      });
+    }
+
+    return post;
   }
 
   findByUser(userId: string) {
@@ -79,6 +97,10 @@ export class PostsService {
 
   async getPostWithAuthor(postId: string) {
     const post = await this.prisma.post.findUnique({ where: { id: postId } });
+
+    if (!post) {
+      throw new NotFoundException('Post not found');
+    }
 
     const authorProfile = await this.userRestService.getUserProfile(
       post.userId,


### PR DESCRIPTION
- Refactored media attachment logic into post-association module
- Renamed controller, module, and route for clarity
- Updated references and imports
- Improved code organization and naming for associating media with posts

This PR implements Day 38 requirements for media-post association.