### PR TITLE
Cleanup Event Bus Library Remnants

### DIFF
--- a/apps/notification-service/tsconfig.json
+++ b/apps/notification-service/tsconfig.json
@@ -1,25 +1,16 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "declaration": true,
-    "removeComments": true,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "allowSyntheticDefaultImports": true,
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
-    "paths": {
-      "@app/event-bus": ["../../libs/event-bus/src"],
-      "@app/event-bus/*": ["../../libs/event-bus/src/*"]
-    },
+    "paths": {},
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
-    "noImplicitAny": false,
-    "strictBindCallApply": false,
-    "noFallthroughCasesInSwitch": false
+    "noImplicitAny": true,
+    "strict": true
   }
 }

--- a/apps/post-service/tsconfig.json
+++ b/apps/post-service/tsconfig.json
@@ -1,25 +1,16 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "declaration": true,
-    "removeComments": true,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "allowSyntheticDefaultImports": true,
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
-    "paths": {
-      "@app/event-bus/*": ["../../libs/event-bus/dist/*"],
-      "@app/event-bus": ["../../libs/event-bus/dist"]
-    },
+    "paths": {},
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
-    "noImplicitAny": false,
-    "strictBindCallApply": false,
-    "noFallthroughCasesInSwitch": false
+    "noImplicitAny": true,
+    "strict": true
   }
 }


### PR DESCRIPTION
Remove remaining local changes and references to the deleted event bus library

Changes:
- Clean up local service and module files
- Remove event bus import paths
- Simplify tsconfig configurations