### PR TITLE
feat(auth): set JWT as HttpOnly cookie on login, improve frontend login/signup UX with Next.js Link navigation and redirects

### DIFF
--- a/apps/auth-service/package-lock.json
+++ b/apps/auth-service/package-lock.json
@@ -18,6 +18,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.1.6",
         "@prisma/client": "^6.7.0",
+        "@sendgrid/mail": "^8.1.5",
         "@types/argon2": "^0.15.4",
         "@types/date-fns": "^2.6.3",
         "argon2": "^0.43.0",
@@ -3203,6 +3204,41 @@
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "dev": true
     },
+    "node_modules/@sendgrid/client": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.5.tgz",
+      "integrity": "sha512-Jqt8aAuGIpWGa15ZorTWI46q9gbaIdQFA21HIPQQl60rCjzAko75l3D1z7EyjFrNr4MfQ0StusivWh8Rjh10Cg==",
+      "dependencies": {
+        "@sendgrid/helpers": "^8.0.0",
+        "axios": "^1.8.2"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.5.tgz",
+      "integrity": "sha512-W+YuMnkVs4+HA/bgfto4VHKcPKLc7NiZ50/NH2pzO6UHCCFuq8/GNB98YJlLEr/ESDyzAaDr7lVE7hoBwFTT3Q==",
+      "dependencies": {
+        "@sendgrid/client": "^8.1.5",
+        "@sendgrid/helpers": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -5203,7 +5239,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
       "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -6222,7 +6257,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7238,7 +7272,6 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -10135,8 +10168,7 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "peer": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/apps/auth-service/package.json
+++ b/apps/auth-service/package.json
@@ -33,6 +33,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.1.6",
     "@prisma/client": "^6.7.0",
+    "@sendgrid/mail": "^8.1.5",
     "@types/argon2": "^0.15.4",
     "@types/date-fns": "^2.6.3",
     "argon2": "^0.43.0",

--- a/apps/auth-service/src/auth/auth.module.ts
+++ b/apps/auth-service/src/auth/auth.module.ts
@@ -7,6 +7,8 @@ import { JwtStrategy } from './strategy/jwt.strategy';
 import { UserRestService } from '../external/user/user.rest.service';
 import { HttpModule } from '@nestjs/axios';
 import { NotificationRestService } from '../external/notification/notification.rest.service';
+import { SendGridModule } from '../sendgrid/sendgrid.module';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
   imports: [
@@ -16,6 +18,8 @@ import { NotificationRestService } from '../external/notification/notification.r
       secret: process.env.JWT_SECRET,
       signOptions: { expiresIn: process.env.JWT_EXPIRES_IN },
     }),
+    SendGridModule,
+    ConfigModule,
   ],
   controllers: [AuthController],
   providers: [

--- a/apps/auth-service/src/sendgrid/sendgrid.module.ts
+++ b/apps/auth-service/src/sendgrid/sendgrid.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { SendGridService } from './sendgrid.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [SendGridService],
+  exports: [SendGridService],
+})
+export class SendGridModule {}

--- a/apps/auth-service/src/sendgrid/sendgrid.service.ts
+++ b/apps/auth-service/src/sendgrid/sendgrid.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as sgMail from '@sendgrid/mail';
+
+@Injectable()
+export class SendGridService {
+  private readonly logger = new Logger(SendGridService.name);
+  private readonly fromEmail: string;
+
+  constructor(private readonly configService: ConfigService) {
+    const apiKey = this.configService.get<string>('SENDGRID_API_KEY');
+    if (!apiKey) {
+      throw new Error('SENDGRID_API_KEY is not configured');
+    }
+    this.fromEmail = this.configService.get<string>(
+      'FROM_EMAIL',
+      'noreply@yourapp.com',
+    );
+    sgMail.setApiKey(apiKey);
+  }
+
+  async sendEmail(to: string, subject: string, text: string, html?: string) {
+    try {
+      const msg = {
+        to,
+        from: this.fromEmail,
+        subject,
+        text,
+        ...(html && { html }), // Include HTML content if provided
+      };
+
+      this.logger.debug(`Sending email to: ${to}, Subject: ${subject}`);
+      await sgMail.send(msg);
+      this.logger.log(`Email sent successfully to: ${to}`);
+      return { success: true };
+    } catch (error) {
+      this.logger.error(
+        `Failed to send email to ${to}: ${error.message}`,
+        error.stack,
+      );
+      throw new Error(`Failed to send email: ${error.message}`);
+    }
+  }
+}

--- a/apps/frontend-nextjs/next.config.js
+++ b/apps/frontend-nextjs/next.config.js
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'http://localhost:3001/:path*', // Proxy to Auth Service
+      },
+    ];
+  },
+};
+
+module.exports = nextConfig;

--- a/apps/frontend-nextjs/package-lock.json
+++ b/apps/frontend-nextjs/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.3",
+        "@tanstack/react-query": "^5.79.2",
         "axios": "^1.9.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1118,6 +1119,30 @@
         "tailwindcss": "4.1.4"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.79.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.79.2.tgz",
+      "integrity": "sha512-kr+KQrBuqd6495eP9S41BoftFI1H50XA9O+6FmbnTx/Te6bjiq1mj8rt9rJjW3YZSO2aaUNUres0TWesJW1j1g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.79.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.79.2.tgz",
+      "integrity": "sha512-kadeprsH6bWuhHCpqukXHRykJkxcLBxAaF0cQ05yawPmLZ/KiCpR1DyQenonF7A/70rnRUxhJD0RJejqk9wImQ==",
+      "dependencies": {
+        "@tanstack/query-core": "5.79.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
@@ -1159,7 +1184,7 @@
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2130,7 +2155,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",

--- a/apps/frontend-nextjs/package.json
+++ b/apps/frontend-nextjs/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
+    "@tanstack/react-query": "^5.79.2",
     "axios": "^1.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/frontend-nextjs/src/app/auth/login/page.tsx
+++ b/apps/frontend-nextjs/src/app/auth/login/page.tsx
@@ -1,0 +1,10 @@
+import { LoginForm } from "@/components/auth/login-form";
+
+export default function LoginPage() {
+  return (
+    <div className="max-w-md mx-auto p-6">
+      <h1 className="text-2xl mb-4 font-semibold text-center">Login</h1>
+      <LoginForm />
+    </div>
+  );
+}

--- a/apps/frontend-nextjs/src/app/auth/signup/page.tsx
+++ b/apps/frontend-nextjs/src/app/auth/signup/page.tsx
@@ -1,0 +1,10 @@
+import { SignupForm } from "@/components/auth/signup-form";
+
+export default function SignupPage() {
+  return (
+    <div className="max-w-md mx-auto p-6">
+      <h1 className="text-2xl mb-4 font-semibold text-center">Sign Up</h1>
+      <SignupForm />
+    </div>
+  );
+}

--- a/apps/frontend-nextjs/src/app/layout.tsx
+++ b/apps/frontend-nextjs/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import ReactQueryProvider from "@/components/providers/react-query-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <ReactQueryProvider>{children}</ReactQueryProvider>
       </body>
     </html>
   );

--- a/apps/frontend-nextjs/src/components/auth/login-form.tsx
+++ b/apps/frontend-nextjs/src/components/auth/login-form.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { api } from "@/lib/axios";
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+export function LoginForm() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const router = useRouter();
+
+  const login = useMutation({
+    mutationFn: async () => {
+      setError("");
+      setSuccess("");
+      return api.post("/auth/login", { email, password });
+    },
+    onSuccess: () => {
+      setSuccess("Login successful! Redirecting...");
+      setTimeout(() => router.push("/feed"), 1000);
+    },
+    onError: (err: any) => {
+      setError(err?.response?.data?.message || "Login failed");
+    },
+  });
+
+  return (
+    <>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          login.mutate();
+        }}
+        className="space-y-4"
+      >
+      <Input
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        type="email"
+        required
+      />
+      <Input
+        placeholder="Password"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      <Button type="submit" disabled={login.isPending} className="w-full">
+        {login.isPending ? "Logging in..." : "Login"}
+      </Button>
+      {error && <div className="text-red-500 text-sm">{error}</div>}
+      {success && <div className="text-green-600 text-sm">{success}</div>}
+    </form>
+    <div className="text-center mt-4 text-sm">
+      Don&apos;t have an account?{' '}
+      <Link href="/auth/signup" className="text-blue-600 hover:underline font-medium">Sign Up</Link>
+    </div>
+    </>
+  );
+}

--- a/apps/frontend-nextjs/src/components/auth/signup-form.tsx
+++ b/apps/frontend-nextjs/src/components/auth/signup-form.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { api } from "@/lib/axios";
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+export function SignupForm() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  const signup = useMutation({
+    mutationFn: async () => {
+      setError("");
+      setSuccess("");
+      return api.post("/auth/signup", { email, password });
+    },
+    onSuccess: () => {
+      setSuccess("Signup successful! Please check your email or login.");
+    },
+    onError: (err: any) => {
+      setError(err?.response?.data?.message || "Signup failed");
+    },
+  });
+
+  return (
+    <>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          signup.mutate();
+        }}
+        className="space-y-4"
+      >
+        <Input
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          type="email"
+          required
+        />
+        <Input
+          placeholder="Password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <Button type="submit" disabled={signup.isPending} className="w-full">
+          {signup.isPending ? "Signing up..." : "Sign Up"}
+        </Button>
+        {error && <div className="text-red-500 text-sm">{error}</div>}
+        {success && <div className="text-green-600 text-sm">{success}</div>}
+      </form>
+      <div className="text-center mt-4 text-sm">
+        Already have an account?{' '}
+        <Link href="/auth/login" className="text-blue-600 hover:underline font-medium">Login</Link>
+      </div>
+    </>
+  );
+}

--- a/apps/frontend-nextjs/src/components/providers/react-query-provider.tsx
+++ b/apps/frontend-nextjs/src/components/providers/react-query-provider.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode, useState } from "react";
+
+export default function ReactQueryProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [queryClient] = useState(() => new QueryClient());
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/apps/frontend-nextjs/src/components/ui/input.tsx
+++ b/apps/frontend-nextjs/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/apps/frontend-nextjs/src/lib/axios.ts
+++ b/apps/frontend-nextjs/src/lib/axios.ts
@@ -1,0 +1,6 @@
+import axios from "axios";
+
+export const api = axios.create({
+  baseURL: "/api", // Goes through the API gateway
+  withCredentials: true, // Important for HttpOnly cookie
+});

--- a/apps/user-service/src/profiles/profiles.controller.ts
+++ b/apps/user-service/src/profiles/profiles.controller.ts
@@ -20,7 +20,6 @@ import {
 } from '@nestjs/swagger';
 import { CreateProfileDto } from './dto/create-profile.dto';
 
-@UseGuards(JwtAuthGuard)
 @ApiTags('Profiles')
 @ApiBearerAuth()
 @Controller('profile')
@@ -39,6 +38,7 @@ export class ProfilesController {
   }
 
   @Get(':id')
+  @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'Get user profile by user ID' })
   @ApiResponse({ status: 200, description: 'User profile found' })
   @ApiResponse({ status: 404, description: 'Profile not found' })
@@ -53,6 +53,7 @@ export class ProfilesController {
   }
 
   @Put()
+  @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'Update your profile' })
   @ApiResponse({ status: 200, description: 'Profile updated' })
   @ApiBody({
@@ -66,6 +67,7 @@ export class ProfilesController {
       },
     },
   })
+  @UseGuards(JwtAuthGuard)
   async updateProfile(
     @Req() req,
     @Body() body: { bio?: string; avatarUrl?: string },


### PR DESCRIPTION
- Set JWT access token as HttpOnly cookie on login in AuthController
- Improved frontend login/signup forms: Next.js Link for navigation, redirect to /feed after login
- Added Next.js API proxy config for local dev
- Polished UX and followed security best practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added email verification via SendGrid for user signup and verification processes.
	- Introduced login and signup pages with corresponding forms in the frontend.
	- Integrated React Query for efficient data fetching and state management in the frontend.
	- Implemented a reusable styled input component for forms.
	- Added a proxy configuration to route frontend API requests to the backend.

- **Improvements**
	- Login now sets the access token as an HttpOnly cookie for enhanced security.
	- Email verification responses now display user-friendly HTML pages.

- **Dependency Updates**
	- Added SendGrid and React Query dependencies to backend and frontend applications.

- **Security**
	- Refined authentication guard usage to protect specific user profile routes only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->