### PR TITLE
feat(profile): allow editing name, bio, and avatar with image upload only

### DIFF
--- a/apps/frontend-nextjs/src/app/profile/[id]/page.tsx
+++ b/apps/frontend-nextjs/src/app/profile/[id]/page.tsx
@@ -43,5 +43,6 @@ export default async function ProfilePage({
       </div>
     );
 
+  // Hydrate user for client (edit mode needs client-side state)
   return <UserProfile user={data} />;
 }

--- a/apps/frontend-nextjs/src/components/profile/profile-edit-form.tsx
+++ b/apps/frontend-nextjs/src/components/profile/profile-edit-form.tsx
@@ -1,0 +1,199 @@
+"use client";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { api } from "@/lib/axios";
+import { toast } from "sonner";
+import Image from "next/image";
+import { Loader2, Paperclip, X } from "lucide-react";
+import { useRef } from "react";
+
+interface ProfileEditFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialName: string | null;
+  initialBio: string | null;
+  initialAvatarUrl: string | null;
+  onProfileUpdated: (name: string, bio: string, avatarUrl: string) => void;
+}
+
+export function ProfileEditForm({
+  open,
+  onOpenChange,
+  initialName,
+  initialBio,
+  initialAvatarUrl,
+  onProfileUpdated,
+}: ProfileEditFormProps) {
+  const [name, setName] = useState(initialName || "");
+  const [bio, setBio] = useState(initialBio || "");
+  const [avatarUrl, setAvatarUrl] = useState(initialAvatarUrl || "");
+  const [loading, setLoading] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(
+    initialAvatarUrl || null
+  );
+  const [file, setFile] = useState<File | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = e.target.files?.[0];
+    if (!selectedFile) return;
+    setFile(selectedFile);
+    setPreviewUrl(URL.createObjectURL(selectedFile));
+    setUploading(true);
+    try {
+      // 1. Get pre-signed URL
+      const { data: urlRes } = await api.post("/media/upload-url", {
+        fileType: selectedFile.type,
+      });
+      const { uploadUrl, fileUrl } = urlRes.data;
+
+      // 2. Upload file to S3
+      await api.put(uploadUrl, selectedFile, {
+        headers: { "Content-Type": selectedFile.type },
+      });
+      // 3. Save metadata
+      const { data: metaRes } = await api.post("/media/metadata", {
+        url: fileUrl,
+        type: selectedFile.type,
+        size: selectedFile.size,
+      });
+      setAvatarUrl(fileUrl);
+      toast.success("Avatar uploaded!");
+    } catch (err) {
+      if (err instanceof Error) {
+        console.error("Upload failed:", err.message, err.stack);
+      } else {
+        console.error("Upload failed:", err);
+      }
+      toast.error("Avatar upload failed");
+      setPreviewUrl(initialAvatarUrl || null);
+      setFile(null);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleRemovePreview = () => {
+    setFile(null);
+    setPreviewUrl(null);
+    setAvatarUrl("");
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await api.put("/profile", { name, bio, avatarUrl });
+      toast.success("Profile updated successfully");
+      onProfileUpdated(name, bio, avatarUrl);
+      onOpenChange(false);
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message || "Failed to update profile");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Profile</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Name</label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Your name"
+              className="mb-3"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Avatar</label>
+            <div className="flex items-center gap-2">
+              <input
+                type="file"
+                accept="image/*"
+                ref={fileInputRef}
+                onChange={handleFileChange}
+                className="hidden"
+                id="avatar-upload"
+              />
+              <Button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading}
+                variant="outline"
+                size="icon"
+                aria-label="Upload avatar"
+              >
+                {uploading ? (
+                  <Loader2 className="animate-spin w-5 h-5" />
+                ) : (
+                  <Paperclip className="w-5 h-5" />
+                )}
+              </Button>
+              {previewUrl && (
+                <div className="relative w-fit max-w-[80px]">
+                  <Image
+                    src={previewUrl}
+                    alt="Avatar Preview"
+                    className="rounded border border-gray-200 bg-white object-cover max-h-16"
+                    width={48}
+                    height={48}
+                  />
+                  <Button
+                    type="button"
+                    onClick={handleRemovePreview}
+                    size="icon"
+                    variant="ghost"
+                    className="absolute top-1 right-1 bg-white hover:bg-gray-100 shadow p-1 h-5 w-5"
+                    aria-label="Remove avatar"
+                  >
+                    <X className="w-3 h-3 text-gray-600" />
+                  </Button>
+                </div>
+              )}
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Bio</label>
+            <Textarea
+              value={bio}
+              onChange={(e) => setBio(e.target.value)}
+              placeholder="Tell us about yourself..."
+            />
+          </div>
+          <div className="flex gap-2 mt-4">
+            <Button
+              type="submit"
+              loading={loading}
+              disabled={loading}
+              className="flex-1"
+            >
+              Save
+            </Button>
+            <DialogClose asChild>
+              <Button type="button" variant="secondary" className="flex-1">
+                Cancel
+              </Button>
+            </DialogClose>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend-nextjs/src/components/profile/user-profile.tsx
+++ b/apps/frontend-nextjs/src/components/profile/user-profile.tsx
@@ -1,25 +1,93 @@
+"use client";
+import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import Image from "next/image";
 import { User } from "@/types/user";
+import { Button } from "@/components/ui/button";
+import { ProfileEditForm } from "./profile-edit-form";
+import { api } from "@/lib/axios";
 
-// FollowButton will be implemented in the next step
 export function UserProfile({ user }: { user: User }) {
+  const [editOpen, setEditOpen] = useState(false);
+  const [profile, setProfile] = useState<User>(user);
+  const [isMe, setIsMe] = useState(false);
+
+  useEffect(() => {
+    async function checkMe() {
+      try {
+        const res = await api.get("/profile/me");
+        if (res.data?.data?.userId === user.userId) setIsMe(true);
+      } catch {}
+    }
+    checkMe();
+  }, [user.userId]);
+
+  const handleProfileUpdated = (
+    name: string,
+    bio: string,
+    avatarUrl: string
+  ) => {
+    setProfile((prev) => ({ ...prev, name, bio, avatarUrl }));
+  };
+
   return (
     <Card className="max-w-xl mx-auto mt-6">
       <CardContent className="flex flex-col items-center text-center p-6 space-y-4">
-        <Image
-          src={user.avatarUrl || "/default-avatar.png"}
-          alt="Avatar"
-          width={96}
-          height={96}
-          className="w-24 h-24 rounded-full border"
-        />
-        <h2 className="text-xl font-semibold">{user.name || "Unnamed User"}</h2>
-        <p className="text-gray-600">{user.bio || "No bio yet."}</p>
-        <div className="flex flex-col items-center gap-1 mt-2">
-          <span className="text-xs text-gray-500">Joined: {new Date(user.createdAt).toLocaleDateString()}</span>
-          <span className="text-xs text-gray-400">Last updated: {new Date(user.updatedAt).toLocaleDateString()}</span>
+        <div className="relative">
+          <Image
+            src={profile.avatarUrl || "/default-avatar.png"}
+            alt="Avatar"
+            width={96}
+            height={96}
+            className="w-24 h-24 rounded-full border object-cover"
+          />
+          {isMe && (
+            <Button
+              size="icon"
+              variant="outline"
+              className="absolute bottom-0 right-0 rounded-full shadow"
+              onClick={() => setEditOpen(true)}
+              aria-label="Edit profile"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="w-5 h-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15.232 5.232l3.536 3.536m-2.036-5.036A2.5 2.5 0 1117.5 8.5L7 19H3v-4l10.5-10.5z"
+                />
+              </svg>
+            </Button>
+          )}
         </div>
+        <h2 className="text-xl font-semibold">
+          {profile.name || "Unnamed User"}
+        </h2>
+        <p className="text-gray-600 whitespace-pre-line">
+          {profile.bio || "No bio yet."}
+        </p>
+        <div className="flex flex-col items-center gap-1 mt-2">
+          <span className="text-xs text-gray-500">
+            Joined: {new Date(profile.createdAt).toLocaleDateString()}
+          </span>
+          <span className="text-xs text-gray-400">
+            Last updated: {new Date(profile.updatedAt).toLocaleDateString()}
+          </span>
+        </div>
+        <ProfileEditForm
+          open={editOpen}
+          onOpenChange={setEditOpen}
+          initialName={profile.name}
+          initialBio={profile.bio}
+          initialAvatarUrl={profile.avatarUrl}
+          onProfileUpdated={handleProfileUpdated}
+        />
       </CardContent>
     </Card>
   );

--- a/apps/user-service/src/profiles/profiles.controller.ts
+++ b/apps/user-service/src/profiles/profiles.controller.ts
@@ -99,6 +99,7 @@ export class ProfilesController {
   @ApiBody({
     schema: {
       properties: {
+        name: { type: 'string', example: 'John Doe' },
         bio: { type: 'string', example: 'About me' },
         avatarUrl: {
           type: 'string',
@@ -110,7 +111,7 @@ export class ProfilesController {
   @UseGuards(JwtAuthGuard)
   async updateProfile(
     @Req() req,
-    @Body() body: { bio?: string; avatarUrl?: string },
+    @Body() body: { name?: string; bio?: string; avatarUrl?: string },
   ) {
     const userId = req.user.userId;
     const updatedProfile = await this.profilesService.updateProfile(

--- a/apps/user-service/src/profiles/profiles.service.ts
+++ b/apps/user-service/src/profiles/profiles.service.ts
@@ -62,7 +62,7 @@ export class ProfilesService {
 
   async updateProfile(
     userId: string,
-    data: { bio?: string; avatarUrl?: string },
+    data: { name?: string; bio?: string; avatarUrl?: string },
   ) {
     try {
       const updatedProfile = await this.prisma.profile.update({


### PR DESCRIPTION
- Users can now edit their name, bio, and avatar image from the profile page.
- Avatar must be uploaded (no manual URL input).
- Backend and frontend fully integrated.
- UI is modern, clean, and uses shadcn/ui components.

This PR closes the loop on profile editing UX and API.