### PR TITLE
fix: update auth-service image reference in Terraform task definition for infra automation

### DIFF
--- a/infrastructure/ecs/task-definitions/auth-service.json
+++ b/infrastructure/ecs/task-definitions/auth-service.json
@@ -1,0 +1,28 @@
+{
+  "family": "auth-service-task",
+  "networkMode": "bridge",
+  "containerDefinitions": [
+    {
+      "name": "auth-service",
+      "image": "ghcr.io/omkardongre/auth-service:latest",
+      "portMappings": [
+        {
+          "containerPort": 3000,
+          "hostPort": 3001
+        }
+      ],
+      "essential": true,
+      "environmentFiles": [
+        {
+          "value": "arn:aws:s3:::socialhub-env-files/auth-service.env",
+          "type": "s3"
+        }
+      ],
+      "cpu": "256",
+      "memory": "512"
+    }
+  ],
+  "requiresCompatibilities": ["EC2"],
+  "cpu": "256",
+  "memory": "512"
+}


### PR DESCRIPTION
This PR updates the auth-service image reference in the Terraform ECS task definition to point to the correct image. This is part of infrastructure automation and ensures the ECS service pulls the right container image.