### PR TITLE
refactor: move RabbitMQ config to env vars, unify docker-compose env usage

### DIFF
--- a/apps/notification-service/src/env.ts
+++ b/apps/notification-service/src/env.ts
@@ -6,4 +6,6 @@ export const env = cleanEnv(process.env, {
   SENDGRID_API_KEY: str(),
   FROM_EMAIL: str(),
   REDIS_URL: str(),
+  RABBITMQ_URL: str(),
+  RABBITMQ_QUEUE: str(),
 });

--- a/apps/notification-service/src/main.ts
+++ b/apps/notification-service/src/main.ts
@@ -24,8 +24,8 @@ async function bootstrap(): Promise<void> {
   app.connectMicroservice({
     transport: Transport.RMQ,
     options: {
-      urls: ['amqp://guest:guest@rabbitmq:5672'],
-      queue: 'notifications_queue',
+      urls: [env.RABBITMQ_URL],
+      queue: env.RABBITMQ_QUEUE,
       queueOptions: {
         durable: true,
       },

--- a/apps/post-service/src/app.module.ts
+++ b/apps/post-service/src/app.module.ts
@@ -1,5 +1,4 @@
 import { Module } from '@nestjs/common';
-import { ClientsModule, Transport } from '@nestjs/microservices';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PostsModule } from './posts/posts.module';
@@ -9,25 +8,7 @@ import { UserRestService } from './external/user/user.rest.service';
 import { HttpModule } from '@nestjs/axios';
 
 @Module({
-  imports: [
-    ClientsModule.register([
-      {
-        name: 'RABBITMQ_SERVICE',
-        transport: Transport.RMQ,
-        options: {
-          urls: ['amqp://guest:guest@rabbitmq:5672'],
-          queue: 'post_created_queue',
-          queueOptions: {
-            durable: false,
-          },
-        },
-      },
-    ]),
-    PostsModule,
-    CommentsModule,
-    LikesModule,
-    HttpModule,
-  ],
+  imports: [PostsModule, CommentsModule, LikesModule, HttpModule],
   controllers: [AppController],
   providers: [AppService, UserRestService],
 })

--- a/apps/post-service/src/env.ts
+++ b/apps/post-service/src/env.ts
@@ -6,4 +6,6 @@ export const env = cleanEnv(process.env, {
   USER_SERVICE_URL: str(),
   JWT_EXPIRES_IN: str(),
   PORT: port({ default: 3000 }),
+  RABBITMQ_URL: str(),
+  RABBITMQ_QUEUE: str(),
 });

--- a/apps/post-service/src/rabbitmq/rabbitmq.module.ts
+++ b/apps/post-service/src/rabbitmq/rabbitmq.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ClientsModule, Transport } from '@nestjs/microservices';
+import { env } from '../env';
 
 @Module({
   imports: [
@@ -8,8 +9,8 @@ import { ClientsModule, Transport } from '@nestjs/microservices';
         name: 'RABBITMQ_SERVICE',
         transport: Transport.RMQ,
         options: {
-          urls: ['amqp://guest:guest@rabbitmq:5672'],
-          queue: 'notifications_queue',
+          urls: [env.RABBITMQ_URL],
+          queue: env.RABBITMQ_QUEUE,
           queueOptions: {
             durable: true,
           },

--- a/apps/user-service/src/env.ts
+++ b/apps/user-service/src/env.ts
@@ -5,4 +5,6 @@ export const env = cleanEnv(process.env, {
   JWT_SECRET: str(),
   JWT_EXPIRES_IN: str(),
   PORT: port({ default: 3000 }),
+  RABBITMQ_URL: str(),
+  RABBITMQ_QUEUE: str(),
 });

--- a/apps/user-service/src/rabbitmq/rabbitmq.module.ts
+++ b/apps/user-service/src/rabbitmq/rabbitmq.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ClientsModule, Transport } from '@nestjs/microservices';
+import { env } from '../env';
 
 @Module({
   imports: [
@@ -8,8 +9,8 @@ import { ClientsModule, Transport } from '@nestjs/microservices';
         name: 'RABBITMQ_SERVICE',
         transport: Transport.RMQ,
         options: {
-          urls: ['amqp://guest:guest@rabbitmq:5672'],
-          queue: 'notifications_queue',
+          urls: [env.RABBITMQ_URL],
+          queue: env.RABBITMQ_QUEUE,
           queueOptions: {
             durable: true,
           },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
     ports:
       - "3001:3000"
     env_file:
-      - ./apps/auth-service/.env.production
+      - ./apps/auth-service/.env
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -92,7 +92,7 @@ services:
     ports:
       - "3002:3000"
     env_file:
-      - ./apps/user-service/.env.production
+      - ./apps/user-service/.env
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -106,7 +106,7 @@ services:
     ports:
       - "3003:3000"
     env_file:
-      - ./apps/post-service/.env.production
+      - ./apps/post-service/.env
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -120,7 +120,7 @@ services:
     ports:
       - "3004:3000"
     env_file:
-      - ./apps/media-service/.env.production
+      - ./apps/media-service/.env
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -134,7 +134,7 @@ services:
     ports:
       - "3005:3000"
     env_file:
-      - ./apps/notification-service/.env.production
+      - ./apps/notification-service/.env
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -148,7 +148,7 @@ services:
     ports:
       - "3006:3000"
     env_file:
-      - ./apps/chat-service/.env.production
+      - ./apps/chat-service/.env
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -162,7 +162,7 @@ services:
     ports:
       - "3007:3000"
     env_file:
-      - ./apps/frontend-nextjs/.env.production
+      - ./apps/frontend-nextjs/.env
 
   api-gateway:
     build:
@@ -171,7 +171,7 @@ services:
     ports:
       - "8082:8082"
     env_file:
-      - ./api-gateway/.env.production
+      - ./api-gateway/.env
     depends_on:
       - auth-service
       - user-service


### PR DESCRIPTION
- Updated notification, post, and user services to use RABBITMQ_URL and RABBITMQ_QUEUE from env
- Cleaned up env validation in all affected services
- Updated docker-compose.yml to use .env files for all services
- Minor code cleanup for consistency