### PR TITLE
ci: update GitHub Actions workflow to use matrix with service path for Docker build context (matches local script logic)

### DIFF
--- a/.github/workflows/ghcr-ci.yml
+++ b/.github/workflows/ghcr-ci.yml
@@ -1,0 +1,46 @@
+name: CI - Build and Push to GHCR
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: auth-service
+            path: apps/auth-service
+          - name: user-service
+            path: apps/user-service
+          - name: post-service
+            path: apps/post-service
+          - name: notification-service
+            path: apps/notification-service
+          - name: chat-service
+            path: apps/chat-service
+          - name: media-service
+            path: apps/media-service
+          - name: api-gateway
+            path: api-gateway
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Docker Image
+        run: |
+          IMAGE_NAME=ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}
+          docker build -f ${{ matrix.path }}/Dockerfile -t $IMAGE_NAME:latest .
+          docker push $IMAGE_NAME:latest


### PR DESCRIPTION
- Updated the CI workflow to use a matrix with both service name and service path, matching the logic of the local build-and-push script.
- Now all Docker images are built from the repo root context using the correct Dockerfile path for each service.
- Ensures consistency between local and CI Docker builds.